### PR TITLE
Fix AuthService export

### DIFF
--- a/src/api/v1/auth/auth.controller.ts
+++ b/src/api/v1/auth/auth.controller.ts
@@ -6,10 +6,10 @@ import { container, injectable, delay, inject } from "tsyringe";
 import { AuthenticationError, InternalServerError } from "@utils/errors/";
 import { ApiResponse } from "@utils/Response";
 import { Route, Benchmark, Logger, InvalidateCache, Controller, Cache } from "@utils/decorators";
+import { AuthService } from "@api/v1/auth";
 
 import * as DTO from "./auth.dtos";
 import { UserModel } from "./auth.model";
-import AuthService from "./auth.service";
 
 @Controller({ logging: true, benchmarking: true })
 @injectable()

--- a/src/api/v1/auth/index.ts
+++ b/src/api/v1/auth/index.ts
@@ -1,4 +1,4 @@
-export { default as authRoutes } from './auth.routes';
-export { default as AuthService } from './auth.service';
-export { default as AuthRepository } from './auth.repository';
-export * from './auth.model';
+export { default as authRoutes } from "./auth.routes";
+export { AuthService } from "./auth.service";
+export { default as AuthRepository } from "./auth.repository";
+export * from "./auth.model";


### PR DESCRIPTION
## Summary
- re-export `AuthService` by name
- fix imports to use named AuthService re-export

## Testing
- `npm run build` *(fails: Cannot find name 'User' and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_b_6852ec9fddb0832b9b5d14ce4eba93b6