### PR TITLE
Add auth tests

### DIFF
--- a/src/api/v1/auth/__tests__/auth.routes.test.ts
+++ b/src/api/v1/auth/__tests__/auth.routes.test.ts
@@ -1,0 +1,66 @@
+import "reflect-metadata";
+import express from "express";
+import session from "express-session";
+import request from "supertest";
+import { container } from "tsyringe";
+import errorHandler from "@middlewares/errorHandler";
+import routeNotFound from "@middlewares/routeNotFound";
+
+import { AuthService } from "../auth.service";
+
+const mockService = {
+  login: jest.fn(),
+  register: jest.fn(),
+  getMe: jest.fn(),
+};
+
+// Register mock before importing routes
+container.registerInstance(AuthService, mockService as any);
+
+const authRoutes = require("../auth.routes").default;
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: "test", resave: false, saveUninitialized: true }));
+  app.use("/api/v1/auth", authRoutes);
+  app.use(errorHandler);
+  app.use(routeNotFound);
+  return app;
+};
+
+describe("auth routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("POST /login returns user", async () => {
+    const user = { id: "1", email: "test@example.com" };
+    mockService.login.mockResolvedValue(user);
+
+    const res = await request(buildApp())
+      .post("/api/v1/auth/login")
+      .send({ email: "test@example.com", password: "pass" })
+      .expect(200);
+
+    expect(res.body.data).toEqual(user);
+    expect(mockService.login).toHaveBeenCalledWith("test@example.com", "pass");
+  });
+
+  it("GET /me requires authentication", async () => {
+    const app = buildApp();
+    await request(app).get("/api/v1/auth/me").expect(401);
+  });
+
+  it("GET /me returns current user when authenticated", async () => {
+    const user = { id: "1", email: "a@b.com" };
+    mockService.login.mockResolvedValue(user);
+    mockService.getMe.mockResolvedValue(user);
+
+    const agent = request.agent(buildApp());
+    await agent.post("/api/v1/auth/login").send({ email: "a@b.com", password: "p" }).expect(200);
+
+    const res = await agent.get("/api/v1/auth/me").expect(200);
+    expect(res.body.data).toEqual(user);
+  });
+});

--- a/src/api/v1/auth/__tests__/auth.service.test.ts
+++ b/src/api/v1/auth/__tests__/auth.service.test.ts
@@ -1,0 +1,76 @@
+import "reflect-metadata";
+import { AuthenticationError, UniqueConstraintError } from "@utils/errors";
+import { EventQueue } from "@utils/queue/EventQueue";
+
+import { UserModel } from "../auth.model";
+import { AuthService } from "../auth.service";
+
+const mockRepo = {
+  findByEmail: jest.fn(),
+  createUser: jest.fn(),
+  update: jest.fn(),
+};
+
+const mockQueue = {
+  dispatchMany: jest.fn(),
+};
+
+describe("AuthService", () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new AuthService(mockRepo as any, mockQueue as any);
+  });
+
+  describe("login", () => {
+    it("returns user when credentials are valid", async () => {
+      const user = { id: "1", validatePassword: jest.fn().mockResolvedValue(true) } as any;
+      mockRepo.findByEmail.mockResolvedValue(user);
+
+      const result = await service.login("test@example.com", "password");
+
+      expect(result).toBe(user);
+      expect(mockRepo.findByEmail).toHaveBeenCalledWith("test@example.com");
+      expect(user.validatePassword).toHaveBeenCalledWith("password");
+    });
+
+    it("throws when user is not found", async () => {
+      mockRepo.findByEmail.mockResolvedValue(null);
+
+      await expect(service.login("missing@example.com", "password")).rejects.toBeInstanceOf(
+        AuthenticationError,
+      );
+    });
+
+    it("throws when password is invalid", async () => {
+      const user = { id: "1", validatePassword: jest.fn().mockResolvedValue(false) } as any;
+      mockRepo.findByEmail.mockResolvedValue(user);
+
+      await expect(service.login("user@example.com", "wrong")).rejects.toBeInstanceOf(
+        AuthenticationError,
+      );
+    });
+  });
+
+  describe("register", () => {
+    it("throws when email already exists", async () => {
+      mockRepo.findByEmail.mockResolvedValue({ id: "1" });
+
+      await expect(service.register("u", "e", "p")).rejects.toBeInstanceOf(UniqueConstraintError);
+    });
+
+    it("creates user and dispatches event", async () => {
+      mockRepo.findByEmail.mockResolvedValue(null);
+      const newUser = new UserModel("user", "e@x.com", "hash");
+      mockRepo.createUser.mockResolvedValue(newUser);
+      mockRepo.update.mockImplementation((_id, user) => Promise.resolve(user));
+
+      const result = await service.register("user", "e@x.com", "pass");
+
+      expect(result).toBeInstanceOf(UserModel);
+      expect(mockRepo.createUser).toHaveBeenCalled();
+      expect(mockQueue.dispatchMany).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for AuthService
- add auth route tests with supertest
- fix named import for AuthService

## Testing
- `npm test --silent` *(fails: Redis connection timed out)*

------
https://chatgpt.com/codex/tasks/task_b_6852c31425f8832bb33983f2ab02a5c0