### PR TITLE
Add decorator tests for transactions and benchmarking

### DIFF
--- a/src/utils/__tests__/Benchmark.decorator.test.ts
+++ b/src/utils/__tests__/Benchmark.decorator.test.ts
@@ -1,0 +1,45 @@
+import "reflect-metadata";
+import { createMethodWrapper } from "../decorators/Controller/method-wrapper";
+
+describe("Benchmark Decorator via Controller wrapper", () => {
+  const buildRes = () => ({
+    headersSent: false,
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("logs execution time when benchmarking enabled", async () => {
+    const original = jest.fn().mockResolvedValue("ok");
+    const wrapper = createMethodWrapper(original, "testMethod", true, false);
+    const req = { method: "GET", path: "/" } as any;
+    const res = buildRes();
+    const next = jest.fn();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    await wrapper(req, res as any, next);
+
+    expect(original).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Method "testMethod" took'));
+
+    logSpy.mockRestore();
+  });
+
+  it("does not log when benchmarking disabled", async () => {
+    const original = jest.fn().mockResolvedValue("ok");
+    const wrapper = createMethodWrapper(original, "testMethod", false, false);
+    const req = { method: "GET", path: "/" } as any;
+    const res = buildRes();
+    const next = jest.fn();
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    await wrapper(req, res as any, next);
+
+    expect(logSpy).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+});

--- a/src/utils/__tests__/Transaction.decorator.test.ts
+++ b/src/utils/__tests__/Transaction.decorator.test.ts
@@ -1,0 +1,67 @@
+import "reflect-metadata";
+import { container } from "tsyringe";
+import { Knex } from "knex";
+
+import { Transaction } from "../decorators/Transaction/Transaction";
+import { RequiresTransaction } from "../decorators/Transaction/RequiresTransaction";
+
+class FakeRepository {
+  @RequiresTransaction()
+  async create(data: string, trx: Knex.Transaction): Promise<Knex.Transaction> {
+    return trx;
+  }
+}
+
+class FakeService {
+  constructor(public repo: FakeRepository) {}
+
+  @Transaction()
+  async create(data: string, trx?: Knex.Transaction): Promise<Knex.Transaction> {
+    return this.repo.create(data, trx!);
+  }
+}
+
+describe("Transaction and RequiresTransaction Decorators", () => {
+  let repo: FakeRepository;
+  let service: FakeService;
+  let mockTrx: any;
+  let mockDb: { transaction: jest.Mock };
+  let mockDatabaseManager: any;
+
+  beforeEach(() => {
+    repo = new FakeRepository();
+    service = new FakeService(repo);
+
+    mockTrx = { commit: jest.fn(), rollback: jest.fn() };
+    mockDb = { transaction: jest.fn(async (cb: any) => await cb(mockTrx)) };
+    const mockDatabase = { getInstance: jest.fn(() => mockDb) };
+    mockDatabaseManager = { getDatabase: jest.fn(() => mockDatabase) };
+    jest.spyOn(container, "resolve").mockReturnValue(mockDatabaseManager);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("creates a transaction when none provided", async () => {
+    const result = await service.create("data");
+
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1);
+    expect(result).toBe(mockTrx);
+  });
+
+  it("reuses provided transaction", async () => {
+    const existingTrx = { commit: jest.fn(), rollback: jest.fn() } as any;
+
+    const result = await service.create("data", existingTrx);
+
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(result).toBe(existingTrx);
+  });
+
+  it("throws when repository called without transaction", async () => {
+    await expect(repo.create("data" as any)).rejects.toThrow(
+      "Method create requires a transaction object as the last parameter",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for Transaction and RequiresTransaction decorators
- add tests for benchmarking in controller method wrapper

## Testing
- `npm test -- -t "Transaction and RequiresTransaction"`
- `npm test -- -t "Benchmark Decorator via"`

------
https://chatgpt.com/codex/tasks/task_b_6852f52572a0832babcadd56931e38e6