### PR TITLE
Improve permission service and add tests

### DIFF
--- a/src/api/v1/permission/__tests__/permission.routes.test.ts
+++ b/src/api/v1/permission/__tests__/permission.routes.test.ts
@@ -1,0 +1,56 @@
+import "reflect-metadata";
+import express from "express";
+import session from "express-session";
+import request from "supertest";
+import { container } from "tsyringe";
+import errorHandler from "@middlewares/errorHandler";
+import routeNotFound from "@middlewares/routeNotFound";
+
+import PermissionService from "../permission.service";
+
+const mockService = {
+  getPermissions: jest.fn(),
+  getPermission: jest.fn(),
+  createPermission: jest.fn(),
+  updatePermission: jest.fn(),
+  deletePermission: jest.fn(),
+};
+
+container.registerInstance(PermissionService, mockService as any);
+
+const permissionRoutes = require("../permission.routes").default;
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: "test", resave: false, saveUninitialized: true }));
+  app.use("/api/v1/permission", permissionRoutes);
+  app.use(errorHandler);
+  app.use(routeNotFound);
+  return app;
+};
+
+describe("permission routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("GET /permission returns permissions", async () => {
+    mockService.getPermissions.mockResolvedValue({ permissions: [], total: 0 });
+
+    await request(buildApp()).get("/api/v1/permission").expect(200);
+    expect(mockService.getPermissions).toHaveBeenCalled();
+  });
+
+  it("POST /permission creates permission", async () => {
+    const perm = { id: "1" };
+    mockService.createPermission.mockResolvedValue(perm);
+
+    const res = await request(buildApp())
+      .post("/api/v1/permission")
+      .send({ name: "read:perm" })
+      .expect(201);
+    expect(res.body.data).toEqual(perm);
+    expect(mockService.createPermission).toHaveBeenCalled();
+  });
+});

--- a/src/api/v1/permission/__tests__/permission.service.test.ts
+++ b/src/api/v1/permission/__tests__/permission.service.test.ts
@@ -1,0 +1,64 @@
+import "reflect-metadata";
+import { ResourceAlreadyExistsError, ResourceDoesNotExistError } from "@utils/errors";
+
+import PermissionService from "../permission.service";
+
+const mockRepo = {
+  findAllPaginated: jest.fn(),
+  findById: jest.fn(),
+  findByField: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  deleteById: jest.fn(),
+  findByUserId: jest.fn(),
+};
+
+describe("PermissionService", () => {
+  let service: PermissionService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new PermissionService(mockRepo as any);
+  });
+
+  describe("getPermissionByUserId", () => {
+    it("returns permissions for user", async () => {
+      const perms = [{ id: "1", name: "read" }];
+      mockRepo.findByUserId.mockResolvedValue(perms);
+
+      const result = await service.getPermissionByUserId("user1");
+
+      expect(result).toBe(perms);
+      expect(mockRepo.findByUserId).toHaveBeenCalledWith("user1");
+    });
+
+    it("throws when none found", async () => {
+      mockRepo.findByUserId.mockResolvedValue([]);
+
+      await expect(service.getPermissionByUserId("u")).rejects.toBeInstanceOf(
+        ResourceDoesNotExistError,
+      );
+    });
+  });
+
+  describe("createPermission", () => {
+    it("throws when permission exists", async () => {
+      mockRepo.findByField.mockResolvedValue([{}]);
+
+      await expect(service.createPermission({} as any)).rejects.toBeInstanceOf(
+        ResourceAlreadyExistsError,
+      );
+    });
+
+    it("creates permission", async () => {
+      const perm = { id: "1", name: "create" } as any;
+      mockRepo.findByField.mockResolvedValue(null);
+      mockRepo.create.mockResolvedValue(perm);
+
+      const result = await service.createPermission(perm);
+
+      expect(result).toBe(perm);
+      expect(mockRepo.create).toHaveBeenCalledWith(perm);
+    });
+  });
+});

--- a/src/api/v1/permission/permission.repository.ts
+++ b/src/api/v1/permission/permission.repository.ts
@@ -1,5 +1,6 @@
 //** EXTERNAL LIBRARIES
 import { inject, injectable } from "tsyringe";
+import { Knex } from "knex";
 //** INTERNAL UTILS
 import { KnexRepository } from "@utils/Repository";
 import DatabaseManager from "@db/db.manager";
@@ -32,6 +33,18 @@ class PermissionRepository extends KnexRepository<Permission> {
       data,
       total: Number(totalResult?.total || 0),
     };
+  }
+
+  public async findByUserId(userId: string, trx?: Knex.Transaction): Promise<Permission[]> {
+    const query = trx
+      ? this.db(this.getTableName()).transacting(trx)
+      : this.db(this.getTableName());
+
+    return query
+      .join("role_permissions", "permissions.id", "role_permissions.permission_id")
+      .join("user_roles", "role_permissions.role_id", "user_roles.role_id")
+      .where("user_roles.user_id", userId)
+      .select("permissions.*");
   }
 }
 

--- a/src/api/v1/permission/permission.service.ts
+++ b/src/api/v1/permission/permission.service.ts
@@ -1,8 +1,8 @@
-import { injectable, inject } from 'tsyringe';
-import { ResourceAlreadyExistsError, ResourceDoesNotExistError } from '@utils/errors';
+import { injectable, inject } from "tsyringe";
+import { ResourceAlreadyExistsError, ResourceDoesNotExistError } from "@utils/errors";
 
-import Permission from './permission.model';
-import PermissionRepository from './permission.repository';
+import Permission from "./permission.model";
+import PermissionRepository from "./permission.repository";
 
 @injectable()
 class PermissionService {
@@ -19,24 +19,23 @@ class PermissionService {
   public async getPermission(permissionId: string): Promise<Permission | null> {
     const existingPermission = await this.permissionRepository.findById(permissionId);
     if (!existingPermission) {
-      throw new ResourceDoesNotExistError('Permission not found');
+      throw new ResourceDoesNotExistError("Permission not found");
     }
     return existingPermission;
   }
 
-  //!TODO It should return Permission[] but currently it returns Permission[]
   public async getPermissionByUserId(userId: string): Promise<Permission[]> {
-    const permissions = await this.permissionRepository.findByField('id', userId);
-    if (!permissions) {
-      throw new ResourceDoesNotExistError('Permissions not found');
+    const permissions = await this.permissionRepository.findByUserId(userId);
+    if (!permissions || permissions.length === 0) {
+      throw new ResourceDoesNotExistError("Permissions not found");
     }
     return permissions;
   }
 
   public async createPermission(permission: Permission): Promise<Permission> {
-    const existingPermission = await this.permissionRepository.findByField('name', permission.name);
+    const existingPermission = await this.permissionRepository.findByField("name", permission.name);
     if (existingPermission) {
-      throw new ResourceAlreadyExistsError('Permission already exists');
+      throw new ResourceAlreadyExistsError("Permission already exists");
     }
     return await this.permissionRepository.create(permission);
   }
@@ -54,7 +53,7 @@ class PermissionService {
   private async ensurePermissionExists(permissionId: string): Promise<Permission> {
     const existingPermission = await this.permissionRepository.findById(permissionId);
     if (!existingPermission) {
-      throw new ResourceDoesNotExistError('Permission not found');
+      throw new ResourceDoesNotExistError("Permission not found");
     }
     return existingPermission;
   }


### PR DESCRIPTION
## Summary
- look up permissions by user ID with joins
- handle empty permission lists
- add service and route tests for permissions

## Testing
- `npx jest --runInBand --silent` *(fails: Cannot find module '@middlewares/errorHandler' from permission routes test)*

------
https://chatgpt.com/codex/tasks/task_b_6852fe97b7bc832b878510cf8ec852d9