### PR TITLE
Add PaginateQuery decorator

### DIFF
--- a/src/utils/__tests__/PaginateQuery.decorator.test.ts
+++ b/src/utils/__tests__/PaginateQuery.decorator.test.ts
@@ -1,0 +1,94 @@
+import "reflect-metadata";
+import { PaginateQuery, PaginationResult } from "../decorators/PaginateQuery";
+
+class FakeQueryBuilder<T> {
+  private opts: { limit?: number; offset?: number; count?: boolean } = {};
+  private countAlias = "total";
+  constructor(private rows: T[]) {}
+
+  clone() {
+    const qb = new FakeQueryBuilder(this.rows);
+    qb.opts = { ...this.opts };
+    qb.countAlias = this.countAlias;
+    return qb;
+  }
+
+  limit(n: number) {
+    this.opts.limit = n;
+    return this;
+  }
+
+  offset(n: number) {
+    this.opts.offset = n;
+    return this;
+  }
+
+  count(_col: string, opts?: { as?: string }) {
+    this.opts.count = true;
+    if (opts?.as) this.countAlias = opts.as;
+    return this;
+  }
+
+  first() {
+    return Promise.resolve({ [this.countAlias]: this.rows.length });
+  }
+
+  then(onFulfilled: any, onRejected: any) {
+    return Promise.resolve(this.exec()).then(onFulfilled, onRejected);
+  }
+
+  private exec() {
+    if (this.opts.count) {
+      return [{ [this.countAlias]: this.rows.length }];
+    }
+    const offset = this.opts.offset ?? 0;
+    const end = this.opts.limit !== undefined ? offset + this.opts.limit : undefined;
+    return this.rows.slice(offset, end);
+  }
+}
+
+class TestService {
+  constructor(private rows: Array<{ id: number }>) {}
+
+  @PaginateQuery()
+  list(req: any) {
+    return new FakeQueryBuilder(this.rows);
+  }
+}
+
+describe("PaginateQuery decorator", () => {
+  it("paginates and returns metadata", async () => {
+    const rows = Array.from({ length: 25 }, (_, i) => ({ id: i + 1 }));
+    const service = new TestService(rows);
+    const req = { query: { page: "2", limit: "5" } };
+
+    const result = (await service.list(req)) as PaginationResult<{ id: number }>;
+
+    expect(result.page).toBe(2);
+    expect(result.limit).toBe(5);
+    expect(result.total).toBe(25);
+    expect(result.totalPages).toBe(5);
+    expect(result.data.map((r) => r.id)).toEqual([6, 7, 8, 9, 10]);
+  });
+
+  it("uses defaults and caps limit", async () => {
+    const rows = Array.from({ length: 120 }, (_, i) => ({ id: i + 1 }));
+    const service = new TestService(rows);
+    const req = { query: { page: "2", limit: "150" } };
+
+    const result = (await service.list(req)) as PaginationResult<{ id: number }>;
+
+    expect(result.page).toBe(2);
+    expect(result.limit).toBe(100);
+    expect(result.data.length).toBe(20);
+    expect(result.total).toBe(120);
+    expect(result.totalPages).toBe(2);
+  });
+
+  it("throws when request not provided", async () => {
+    const service = new TestService([]);
+    await expect(service.list(undefined as any)).rejects.toThrow(
+      "@PaginateQuery requires an Express Request object",
+    );
+  });
+});

--- a/src/utils/decorators/PaginateQuery.ts
+++ b/src/utils/decorators/PaginateQuery.ts
@@ -1,0 +1,59 @@
+import { Request } from "express";
+import { Knex } from "knex";
+
+export interface PaginationResult<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export function PaginateQuery() {
+  return function (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) {
+    const originalMethod = descriptor.value;
+
+    descriptor.value = async function (...args: any[]) {
+      const req: Request | undefined = args.find((a) => a && typeof a === "object" && "query" in a);
+
+      if (!req || typeof req.query !== "object") {
+        throw new Error("@PaginateQuery requires an Express Request object");
+      }
+
+      let page = parseInt((req.query as any).page ?? "1", 10);
+      let limit = parseInt((req.query as any).limit ?? "10", 10);
+
+      if (isNaN(page) || page < 1) page = 1;
+      if (isNaN(limit) || limit < 1) limit = 10;
+      if (limit > 100) limit = 100;
+
+      const baseQuery: Knex.QueryBuilder = originalMethod.apply(this, args);
+
+      if (
+        !baseQuery ||
+        typeof baseQuery.clone !== "function" ||
+        typeof baseQuery.limit !== "function"
+      ) {
+        throw new Error("@PaginateQuery method must return a Knex QueryBuilder");
+      }
+
+      const offset = (page - 1) * limit;
+      const dataQuery = baseQuery.clone().limit(limit).offset(offset);
+      const countQuery = baseQuery.clone().count("*", { as: "total" }).first();
+
+      const [data, countResult] = await Promise.all([dataQuery, countQuery]);
+      const total = Number((countResult as any)?.total ?? 0);
+      const totalPages = Math.ceil(total / limit);
+
+      return {
+        data,
+        total,
+        page,
+        limit,
+        totalPages,
+      } as PaginationResult<any>;
+    };
+
+    return descriptor;
+  };
+}

--- a/src/utils/decorators/index.ts
+++ b/src/utils/decorators/index.ts
@@ -5,3 +5,4 @@ export { Route } from "./Route";
 export { Benchmark } from "./Benchmark";
 export { Logger } from "./Logger";
 export { InvalidateCache, Cache } from "./Cache";
+export { PaginateQuery } from "./PaginateQuery";


### PR DESCRIPTION
## Summary
- add `PaginateQuery` method decorator for easy pagination of Knex queries
- expose the new decorator in the decorators index
- test pagination behaviour

## Testing
- `npx jest src/utils/__tests__/PaginateQuery.decorator.test.ts`
- `npm test` *(fails: Cannot find module '@middlewares/errorHandler' from auth.routes.test.ts)*

------
https://chatgpt.com/codex/tasks/task_b_685324fc1084832ba57073770994549a