### PR TITLE
Read Redis config from env

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -138,6 +138,8 @@ LOG_LEVEL=info
 LOG_FILE_PATH=logs/app-%DATE%.log
 ```
 
+`REDIS_HOST` and `REDIS_PORT` control the address of the Redis instance used for session storage. If these variables are not set, the gateway defaults to `redis` and `6379`.
+
 ## Running the Application
 
 ### Development

--- a/src/utils/RedisManager.ts
+++ b/src/utils/RedisManager.ts
@@ -1,5 +1,6 @@
 import { createClient, RedisClientType } from "redis";
 import { singleton } from "tsyringe";
+import Config from "@config/config";
 
 import LoggerFactory from "./Logger";
 
@@ -53,9 +54,11 @@ export class RedisManager {
    * @returns {Promise<void>} A Promise that resolves when the Redis client is successfully initialized.
    */
   private async initRedisClient(timeout: number = 5000, maxRetries: number = 5): Promise<void> {
+    const host = Config.app.session.redis.host || "redis";
+    const port = Config.app.session.redis.port || 6379;
+
     this.redisClient = createClient({
-      url: "redis://redis:6379",
-      //url: `redis://${Config.app.session.redis.host}:${Config.app.session.redis.port}`,
+      url: `redis://${host}:${port}`,
     });
     let attempts = 0;
 


### PR DESCRIPTION
## Summary
- allow RedisManager to read host and port from env via config
- document `REDIS_HOST` and `REDIS_PORT` defaults in README

## Testing
- `npm test --silent` *(fails: PermissionService tests and others)*

------
https://chatgpt.com/codex/tasks/task_b_6853ae99b1ec832b9affda3780f51e6a