### PR TITLE
Add worker service to compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,6 +21,25 @@ services:
       - redis
     networks:
       - express-gateway-network
+  worker:
+    container_name: worker
+    build:
+      context: ./
+      target: ${TARGET_STAGE:-development}
+      args:
+        NODE_ENV: ${NODE_ENV:-development}
+    command: npm run start:worker
+    volumes:
+      - .:/usr/src/app
+      - ./dist/client:/usr/src/app/dist/client
+    env_file:
+      - .env
+    depends_on:
+      - db
+      - redis
+    networks:
+      - express-gateway-network
+
   db:
     container_name: postgres
     image: "postgres:alpine"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,3 +10,17 @@ services:
       - "${PORT:-80}:${PORT:-80}"
     env_file:
       - .env.prod
+
+  worker:
+    build:
+      context: ./
+      target: ${TARGET_STAGE:-production}
+      args:
+        NODE_ENV: ${NODE_ENV:-development}
+    command: npm run start:worker
+    env_file:
+      - .env.prod
+    depends_on:
+      - db
+      - redis
+


### PR DESCRIPTION
## Summary
- add new `worker` service to dev compose setup
- add matching service to prod compose

## Testing
- `npm test --silent` *(fails: Cannot find module '@middlewares/errorHandler')*

------
https://chatgpt.com/codex/tasks/task_b_6853b1087bc0832baa32d0d8000373e3