### PR TITLE
Remove debug log from API v1 index

### DIFF
--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -1,2 +1,1 @@
-export { default as api_v1 } from './api';
-console.log('api_v1');
+export { default as api_v1 } from "./api";


### PR DESCRIPTION
## Summary
- clean up debug log from `src/api/v1/index.ts`

## Testing
- `npx jest --runInBand --silent` *(fails: Cannot find module '@middlewares/errorHandler')*

------
https://chatgpt.com/codex/tasks/task_b_6853aea16c54832b9927293a6c9e2343