### PR TITLE
Add admin health endpoint

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ module.exports = {
     "^@utils/(.*)$": "<rootDir>/src/utils/$1",
     "^@config/(.*)$": "<rootDir>/src/config/$1",
     "^@db/(.*)$": "<rootDir>/src/db/$1",
+    "^@middlewares/(.*)$": "<rootDir>/src/middlewares/$1",
   },
   globals: {
     "ts-jest": {

--- a/src/__tests__/admin.routes.test.ts
+++ b/src/__tests__/admin.routes.test.ts
@@ -1,0 +1,44 @@
+import express, { RequestHandler } from "express";
+import request from "supertest";
+import "reflect-metadata";
+import { container } from "tsyringe";
+import adminOnly from "@middlewares/adminOnly";
+import errorHandler from "@middlewares/errorHandler";
+import { AuthService } from "@api/v1/auth";
+
+const createApp = (middleware: RequestHandler, withSession = true) => {
+  const app = express();
+  if (withSession) {
+    app.use((req, _res, next) => {
+      req.session = { userId: "1" } as any;
+      next();
+    });
+  }
+  app.get("/admin", middleware, (_req, res) => res.json({ success: true }));
+  app.use(errorHandler);
+  return app;
+};
+
+describe("adminOnly middleware", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    container.clearInstances();
+  });
+
+  it("rejects non-admin users", async () => {
+    const mockGetMe = jest.fn().mockResolvedValue({ roles: [{ name: "user" }] });
+    container.registerInstance(AuthService, { getMe: mockGetMe } as any);
+    const app = createApp(adminOnly);
+    const res = await request(app).get("/admin");
+    expect(res.status).toBe(403);
+  });
+
+  it("allows admin users", async () => {
+    const mockGetMe = jest.fn().mockResolvedValue({ roles: [{ name: "Admin" }] });
+    container.registerInstance(AuthService, { getMe: mockGetMe } as any);
+    const app = createApp(adminOnly);
+    const res = await request(app).get("/admin");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});

--- a/src/api/v1/admin/admin.controller.ts
+++ b/src/api/v1/admin/admin.controller.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from "express";
+import { injectable, inject } from "tsyringe";
+import DatabaseManager from "@db/db.manager";
+import { RedisManager } from "@utils/RedisManager";
+import { ApiResponse } from "@utils/Response";
+import { Route } from "@utils/decorators";
+
+@injectable()
+export class AdminController {
+  constructor(
+    @inject(DatabaseManager) private readonly dbManager: DatabaseManager,
+    @inject(RedisManager) private readonly redisManager: RedisManager,
+  ) {}
+
+  @Route()
+  public async health(
+    _req: Request,
+    _res: Response,
+    _next: NextFunction,
+  ): Promise<ApiResponse<{ database: string; redis: string }>> {
+    const db = this.dbManager.getDatabase();
+    await db.query("SELECT 1");
+    await this.redisManager.getRedisClient().ping();
+    return ApiResponse.success({ database: "ok", redis: "ok" }, "Service healthy");
+  }
+}
+
+export default AdminController;

--- a/src/api/v1/admin/admin.routes.ts
+++ b/src/api/v1/admin/admin.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from "express";
+import { container } from "tsyringe";
+import { authRequired } from "@middlewares/authRequired";
+import adminOnly from "@middlewares/adminOnly";
+
+import AdminController from "./admin.controller";
+
+const router = Router();
+const controller = container.resolve(AdminController);
+
+router.use(authRequired, adminOnly);
+router.get("/health", controller.health);
+
+export default router;

--- a/src/api/v1/admin/index.ts
+++ b/src/api/v1/admin/index.ts
@@ -1,0 +1,2 @@
+export { default as adminRoutes } from "./admin.routes";
+export { default as AdminController } from "./admin.controller";

--- a/src/api/v1/api.ts
+++ b/src/api/v1/api.ts
@@ -4,6 +4,7 @@ import { authRoutes } from "./auth";
 import { roleRoutes } from "./role";
 import { permissionRoutes } from "./permission";
 import queueRoutes from "./queue/queue.routes";
+import { adminRoutes } from "./admin";
 
 const router = Router();
 
@@ -15,5 +16,6 @@ router.use("/auth", authRoutes);
 router.use("/role", roleRoutes);
 router.use("/permission", permissionRoutes);
 router.use("/queue", queueRoutes);
+router.use("/admin", adminRoutes);
 
 export default router;

--- a/src/middlewares/adminOnly.ts
+++ b/src/middlewares/adminOnly.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from "express";
+import { container } from "tsyringe";
+import { AuthenticationError, AuthorizationError } from "@utils/errors";
+import { AuthService } from "@api/v1/auth";
+
+/**
+ * Middleware that restricts access to admin users only.
+ */
+export const adminOnly = async (
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const userId = req.session?.userId;
+    if (!userId) {
+      throw new AuthenticationError("Authentication required");
+    }
+
+    const authService = container.resolve(AuthService);
+    const user = await authService.getMe(userId);
+    const isAdmin = user.roles.some((role) => role.name.toLowerCase() === "admin");
+
+    if (!isAdmin) {
+      throw new AuthorizationError("Admin access required");
+    }
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export default adminOnly;

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -4,3 +4,4 @@ export { default as routeNotFound } from "./routeNotFound";
 export { default as validateRequest } from "./validator";
 export { authorization } from "./authorization";
 export { default as authRequired } from "./authRequired";
+export { default as adminOnly } from "./adminOnly";

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { AuthProvider, useAuth } from "./components/AuthContext";
 import Login from "./components/Login";
+import Health from "./components/Health";
 
 interface QueueItem {
   id: string;
@@ -8,7 +9,11 @@ interface QueueItem {
   status: string;
 }
 
-const QueueDashboard = () => {
+interface QueueDashboardProps {
+  isAdmin: boolean;
+}
+
+const QueueDashboard = ({ isAdmin }: QueueDashboardProps) => {
   // State for a message shown in the UI and for the queue items.
   const [msg, setMsg] = useState("Waiting for WebSocket...");
   const [queueItems, setQueueItems] = useState<QueueItem[]>([]);
@@ -110,20 +115,22 @@ const QueueDashboard = () => {
               <li>No jobs found.</li>
             )}
           </ul>
+          {isAdmin && <Health />}
         </div>
       </div>
     </div>
   );
 };
 
-const App = () => {
-  const { isAuthenticated } = useAuth();
-
-  return (
-    <AuthProvider>
-      {isAuthenticated ? <QueueDashboard /> : <Login />}
-    </AuthProvider>
-  );
+const AppContent = () => {
+  const { isAuthenticated, isAdmin } = useAuth();
+  return isAuthenticated ? <QueueDashboard isAdmin={isAdmin} /> : <Login />;
 };
+
+const App = () => (
+  <AuthProvider>
+    <AppContent />
+  </AuthProvider>
+);
 
 export default App;

--- a/src/ui/components/AuthContext.tsx
+++ b/src/ui/components/AuthContext.tsx
@@ -2,6 +2,8 @@ import React, { createContext, useContext, useState } from "react";
 
 interface AuthContextType {
   isAuthenticated: boolean;
+  isAdmin: boolean;
+  user: any | null;
   setAuthenticated: (value: boolean) => void;
   login: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
@@ -11,6 +13,8 @@ const AuthContext = createContext<AuthContextType | null>(null);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [user, setUser] = useState<any | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   const setAuthenticated = (value: boolean) => {
     setIsAuthenticated(value);
@@ -28,6 +32,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       throw new Error("Login failed");
     }
 
+    const data = await response.json();
+    setUser(data.data);
+    const admin = data.data.roles?.some((r: any) => r.name.toLowerCase() === "admin");
+    setIsAdmin(Boolean(admin));
     setIsAuthenticated(true);
   };
 
@@ -37,10 +45,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       credentials: "include",
     });
     setIsAuthenticated(false);
+    setUser(null);
+    setIsAdmin(false);
   };
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, setAuthenticated, login, logout }}>
+    <AuthContext.Provider value={{ isAuthenticated, isAdmin, user, setAuthenticated, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/ui/components/Health.tsx
+++ b/src/ui/components/Health.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+
+interface HealthState {
+  database: string;
+  redis: string;
+}
+
+const Health = () => {
+  const [health, setHealth] = useState<HealthState | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchHealth = async () => {
+      try {
+        const res = await fetch("/api/v1/admin/health", { credentials: "include" });
+        if (!res.ok) {
+          throw new Error("Failed to fetch health");
+        }
+        const data = await res.json();
+        setHealth(data.data);
+      } catch (err) {
+        setError("Failed to load health status");
+      }
+    };
+    fetchHealth();
+  }, []);
+
+  if (error) {
+    return <div className="health">{error}</div>;
+  }
+  if (!health) {
+    return <div className="health">Loading health...</div>;
+  }
+  return (
+    <div className="health">
+      <h2>System Health</h2>
+      <ul>
+        <li>Database: {health.database}</li>
+        <li>Redis: {health.redis}</li>
+      </ul>
+    </div>
+  );
+};
+
+export default Health;


### PR DESCRIPTION
## Summary
- add middleware to restrict access to admins
- implement admin controller and route providing `/admin/health`
- include health check in API router
- expose admin-only health info in React UI
- extend auth context with user data and admin detection
- include jest path mapping for middlewares
- test adminOnly middleware

## Testing
- `npm run lint` *(fails: 207 errors)*
- `npm test` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_b_6853b9fdee68832b925694b082422b05