### PR TITLE
Add role service and routes tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,6 +8,7 @@ module.exports = {
     "^@utils/(.*)$": "<rootDir>/src/utils/$1",
     "^@config/(.*)$": "<rootDir>/src/config/$1",
     "^@db/(.*)$": "<rootDir>/src/db/$1",
+    "^@middlewares(.*)$": "<rootDir>/src/middlewares$1",
   },
   globals: {
     "ts-jest": {

--- a/src/api/v1/role/__tests__/role.routes.test.ts
+++ b/src/api/v1/role/__tests__/role.routes.test.ts
@@ -1,0 +1,92 @@
+import "reflect-metadata";
+import express from "express";
+import session from "express-session";
+import request from "supertest";
+import { container } from "tsyringe";
+import { RoleActions } from "@utils/enums";
+
+import errorHandler from "@/middlewares/errorHandler";
+import routeNotFound from "@/middlewares/routeNotFound";
+import RoleService from "../role.service";
+
+jest.mock("@api/v1/auth", () => ({
+  User: class {},
+  AuthRepository: class {},
+}));
+
+jest.mock("@middlewares", () => ({
+  authorization: jest.fn((perms: string[]) => {
+    const mw = (_req: any, _res: any, next: any) => next();
+    (mw as any).__permissions = perms;
+    return mw;
+  }),
+  validateRequest: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+const { authorization } = require("@middlewares");
+
+const mockService = {
+  getRoles: jest.fn(),
+  getRole: jest.fn(),
+  createRole: jest.fn(),
+  updateRole: jest.fn(),
+  deleteRole: jest.fn(),
+  assignRoleToUser: jest.fn(),
+  removeRoleFromUser: jest.fn(),
+  getUserRoles: jest.fn(),
+  assignPermissionToRole: jest.fn(),
+  removePermissionFromRole: jest.fn(),
+  getRolePermissions: jest.fn(),
+};
+
+container.registerInstance(RoleService, mockService as any);
+let roleRoutes = require("../role.routes").default;
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(session({ secret: "test", resave: false, saveUninitialized: true }));
+  app.use("/api/v1/role", roleRoutes);
+  app.use(errorHandler);
+  app.use(routeNotFound);
+  return app;
+};
+
+describe("role routes", () => {
+  beforeEach(() => {
+    mockService.getRoles.mockReset();
+    mockService.getRole.mockReset();
+    mockService.createRole.mockReset();
+    mockService.updateRole.mockReset();
+    mockService.deleteRole.mockReset();
+    mockService.assignRoleToUser.mockReset();
+    mockService.removeRoleFromUser.mockReset();
+    mockService.getUserRoles.mockReset();
+    mockService.assignPermissionToRole.mockReset();
+    mockService.removePermissionFromRole.mockReset();
+    mockService.getRolePermissions.mockReset();
+  });
+
+  it("GET /role returns roles", async () => {
+    mockService.getRoles.mockResolvedValue([]);
+    await request(buildApp()).get("/api/v1/role").expect(200);
+    expect(mockService.getRoles).toHaveBeenCalled();
+  });
+
+  it("POST /role creates role", async () => {
+    const role = { id: "1" };
+    mockService.createRole.mockResolvedValue(role);
+    const res = await request(buildApp()).post("/api/v1/role").send({ name: "new" }).expect(201);
+    expect(res.body.data).toEqual(role);
+    expect(mockService.createRole).toHaveBeenCalled();
+  });
+
+  it("applies correct permissions", () => {
+    const perms = authorization.mock.calls.map((c: any) => c[0]);
+    expect(perms).toContainEqual([RoleActions.CREATE_ROLE]);
+    expect(perms).toContainEqual([RoleActions.READ_ROLE]);
+    expect(perms).toContainEqual([RoleActions.UPDATE_ROLE]);
+    expect(perms).toContainEqual([RoleActions.DELETE_ROLE]);
+    expect(perms).toContainEqual([RoleActions.ASSIGN_ROLE]);
+    expect(perms).toContainEqual(["assign:permission"]);
+  });
+});

--- a/src/api/v1/role/__tests__/role.service.test.ts
+++ b/src/api/v1/role/__tests__/role.service.test.ts
@@ -1,0 +1,100 @@
+import "reflect-metadata";
+import { ResourceAlreadyExistsError, ResourceDoesNotExistError } from "@utils/errors";
+
+import RoleService from "../role.service";
+
+jest.mock("@api/v1/auth", () => ({
+  User: class {},
+  AuthRepository: class {},
+}));
+
+const mockRoleRepo = {
+  findAll: jest.fn(),
+  findById: jest.fn(),
+  findByField: jest.fn(),
+  create: jest.fn(),
+  update: jest.fn(),
+  deleteById: jest.fn(),
+};
+const mockAuthRepo = { findById: jest.fn() };
+const mockUserRoleRepo = {
+  assignRoleToUser: jest.fn(),
+  removeRoleFromUser: jest.fn(),
+  getUserRoles: jest.fn(),
+  getUsersByRole: jest.fn(),
+};
+const mockPermissionRepo = {
+  assignPermissionToRole: jest.fn(),
+  removePermissionFromRole: jest.fn(),
+  getRolePermissions: jest.fn(),
+};
+
+describe("RoleService", () => {
+  let service: RoleService;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new RoleService(
+      mockRoleRepo as any,
+      mockAuthRepo as any,
+      mockUserRoleRepo as any,
+      mockPermissionRepo as any,
+    );
+  });
+
+  describe("createRole", () => {
+    it("throws when role already exists", async () => {
+      mockRoleRepo.findByField.mockResolvedValue({ id: "1" });
+      await expect(service.createRole({ name: "admin" } as any)).rejects.toMatchObject({
+        code: "RESOURCE_ALREADY_EXISTS",
+      });
+    });
+
+    it("creates role when not existing", async () => {
+      const role = { id: "1", name: "user" } as any;
+      mockRoleRepo.findByField.mockResolvedValue(null);
+      mockRoleRepo.create.mockResolvedValue(role);
+      const result = await service.createRole(role);
+      expect(result).toBe(role);
+      expect(mockRoleRepo.create).toHaveBeenCalledWith(role);
+    });
+  });
+
+  describe("getRole", () => {
+    it("returns role when found", async () => {
+      const role = { id: "1" } as any;
+      mockRoleRepo.findById.mockResolvedValue(role);
+      const result = await service.getRole("1");
+      expect(result).toBe(role);
+    });
+
+    it("throws when missing", async () => {
+      mockRoleRepo.findById.mockResolvedValue(null);
+      await expect(service.getRole("42")).rejects.toMatchObject({
+        code: "RESOURCE_NOT_FOUND",
+      });
+    });
+  });
+
+  describe("assignRoleToUser", () => {
+    it("assigns role when user and role exist", async () => {
+      const user = { id: "u1" } as any;
+      const role = { id: "r1" } as any;
+      mockRoleRepo.findById.mockResolvedValue(role);
+      mockAuthRepo.findById.mockResolvedValueOnce(user).mockResolvedValueOnce(user);
+      mockUserRoleRepo.assignRoleToUser.mockResolvedValue({});
+
+      const result = await service.assignRoleToUser("u1", "r1");
+
+      expect(mockUserRoleRepo.assignRoleToUser).toHaveBeenCalledWith("u1", "r1");
+      expect(result).toBe(user);
+    });
+
+    it("throws when user missing", async () => {
+      mockRoleRepo.findById.mockResolvedValue({ id: "r1" });
+      mockAuthRepo.findById.mockResolvedValue(null);
+      await expect(service.assignRoleToUser("u2", "r1")).rejects.toMatchObject({
+        code: "RESOURCE_NOT_FOUND",
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add moduleNameMapper entry for `@middlewares`
- test role service business logic with mocks
- test role routes and permission middleware

## Testing
- `npx jest src/api/v1/role/__tests__/role.service.test.ts src/api/v1/role/__tests__/role.routes.test.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_6853b8cc8304832bb7bb84cadc25149b