### PR TITLE
Add email verification and password reset

### DIFF
--- a/src/api/v1/auth/__tests__/auth.service.test.ts
+++ b/src/api/v1/auth/__tests__/auth.service.test.ts
@@ -11,6 +11,12 @@ const mockRepo = {
   update: jest.fn(),
 };
 
+const mockTokenRepo = {
+  createToken: jest.fn(),
+  findByToken: jest.fn(),
+  deleteById: jest.fn(),
+};
+
 const mockQueue = {
   dispatchMany: jest.fn(),
 };
@@ -20,7 +26,7 @@ describe("AuthService", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    service = new AuthService(mockRepo as any, mockQueue as any);
+    service = new AuthService(mockRepo as any, mockQueue as any, mockTokenRepo as any);
   });
 
   describe("login", () => {
@@ -57,7 +63,9 @@ describe("AuthService", () => {
     it("throws when email already exists", async () => {
       mockRepo.findByEmail.mockResolvedValue({ id: "1" });
 
-      await expect(service.register("u", "e", "p")).rejects.toBeInstanceOf(UniqueConstraintError);
+      await expect(service.register("u", "e", "p", {} as any)).rejects.toBeInstanceOf(
+        UniqueConstraintError,
+      );
     });
 
     it("creates user and dispatches event", async () => {
@@ -66,7 +74,7 @@ describe("AuthService", () => {
       mockRepo.createUser.mockResolvedValue(newUser);
       mockRepo.update.mockImplementation((_id, user) => Promise.resolve(user));
 
-      const result = await service.register("user", "e@x.com", "pass");
+      const result = await service.register("user", "e@x.com", "pass", {} as any);
 
       expect(result).toBeInstanceOf(UserModel);
       expect(mockRepo.createUser).toHaveBeenCalled();

--- a/src/api/v1/auth/auth.controller.ts
+++ b/src/api/v1/auth/auth.controller.ts
@@ -347,6 +347,32 @@ export class AuthController {
     await this.authService.changePassword(userId, newPassword);
     return ApiResponse.success(null, "Password changed successfully");
   }
+
+  @Route()
+  @Benchmark()
+  @Logger()
+  public async verifyEmail(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<ApiResponse<UserModel>> {
+    const { token } = req.body as DTO.VerifyEmailRequestDTO;
+    const user = await this.authService.verifyEmail(token);
+    return ApiResponse.success(user, "Email verified");
+  }
+
+  @Route()
+  @Benchmark()
+  @Logger()
+  public async resetPassword(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<ApiResponse<UserModel>> {
+    const { token, password } = req.body as DTO.ResetPasswordRequestDTO;
+    const user = await this.authService.resetPassword(token, password);
+    return ApiResponse.success(user, "Password reset successfully");
+  }
 }
 
 export default container.resolve(AuthController);

--- a/src/api/v1/auth/auth.dtos.ts
+++ b/src/api/v1/auth/auth.dtos.ts
@@ -96,3 +96,13 @@ export class VerifyEmailRequestDTO {
   @IsString()
   token: string;
 }
+
+// TODO: Add swagger docs
+export class ResetPasswordRequestDTO {
+  @IsString()
+  token: string;
+
+  @IsString()
+  @Length(6, undefined, { message: "Password must be at least 6 characters long" })
+  password: string;
+}

--- a/src/api/v1/auth/auth.routes.ts
+++ b/src/api/v1/auth/auth.routes.ts
@@ -12,6 +12,16 @@ const authController = container.resolve(AuthController);
 // Public routes (no authentication required)
 router.post("/login", validateRequest(DTO.LoginUserRequestDTO), authController.login);
 router.post("/register", validateRequest(DTO.RegisterUserRequestDTO), authController.register);
+router.post(
+  "/verify-email",
+  validateRequest(DTO.VerifyEmailRequestDTO),
+  authController.verifyEmail,
+);
+router.post(
+  "/reset-password",
+  validateRequest(DTO.ResetPasswordRequestDTO),
+  authController.resetPassword,
+);
 
 // Protected routes (authentication required)
 router.post("/logout", authRequired, authController.logout);

--- a/src/api/v1/auth/auth.service.ts
+++ b/src/api/v1/auth/auth.service.ts
@@ -1,4 +1,5 @@
 import bcrypt from "bcryptjs";
+import crypto from "crypto";
 import { inject, injectable } from "tsyringe";
 import { Knex } from "knex";
 import {
@@ -16,12 +17,16 @@ import { EventType } from "@utils/queue/EventTypes";
 import { UserModel } from "./auth.model";
 import * as DTO from "./auth.dtos";
 import AuthRepository from "./auth.repository";
+import VerificationTokenRepository from "./verification-token.repository";
+import { TokenType } from "./verification-token.model";
 
 @injectable()
 export class AuthService {
   constructor(
     @inject(AuthRepository) private authRepository: AuthRepository,
     @inject(EventQueue) private eventQueue: EventQueue,
+    @inject(VerificationTokenRepository)
+    private tokenRepository: VerificationTokenRepository,
   ) {}
 
   @ExceptionHandler("Failed to register user")
@@ -47,10 +52,26 @@ export class AuthService {
       .transition(UserAction.REGISTER)
       .persist(this.authRepository, trx!);
 
+    const verificationToken = await this.tokenRepository.createToken(
+      entity.id,
+      crypto.randomUUID(),
+      TokenType.EmailVerification,
+      new Date(Date.now() + 1000 * 60 * 60 * 24),
+      trx,
+    );
+
     await this.eventQueue.dispatchMany([
       {
         type: EventType.UserRegistered,
         payload: { userId: entity.id, email: entity.model.email },
+      },
+      {
+        type: EventType.EmailVerification,
+        payload: {
+          userId: entity.id,
+          email: entity.model.email,
+          token: verificationToken.token,
+        },
       },
     ]);
     return entity.toModel();
@@ -133,5 +154,47 @@ export class AuthService {
       console.error("Error validating password:", error);
       throw new ValidationError("Password validation failed");
     }
+  }
+
+  @ExceptionHandler("Failed to verify email")
+  @Transaction()
+  async verifyEmail(token: string, trx?: Knex.Transaction): Promise<UserModel> {
+    const record = await this.tokenRepository.findByToken(token, trx);
+    if (!record || record.type !== TokenType.EmailVerification || record.expiresAt < new Date()) {
+      throw new ValidationError("Invalid or expired token");
+    }
+
+    const user = await this.authRepository.findById(record.userId, trx);
+    if (!user) throw new ResourceDoesNotExistError("User not found");
+
+    user.emailVerified = true;
+
+    const entity = UserEntity.create(user).transition(UserAction.CONFIRM_EMAIL);
+    await entity.persist(this.authRepository, trx!);
+    await this.tokenRepository.deleteById(record.id, trx);
+    return entity.toModel();
+  }
+
+  @ExceptionHandler("Failed to reset password")
+  @Transaction()
+  async resetPassword(
+    token: string,
+    newPassword: string,
+    trx?: Knex.Transaction,
+  ): Promise<UserModel> {
+    const record = await this.tokenRepository.findByToken(token, trx);
+    if (!record || record.type !== TokenType.PasswordReset || record.expiresAt < new Date()) {
+      throw new ValidationError("Invalid or expired token");
+    }
+
+    const user = await this.authRepository.findById(record.userId, trx);
+    if (!user) throw new ResourceDoesNotExistError("User not found");
+
+    const hashed = await bcrypt.hash(newPassword, 10);
+    const entity = UserEntity.create(user).transition(UserAction.RESET_PASSWORD);
+    entity.model.password = hashed;
+    await entity.persist(this.authRepository, trx!);
+    await this.tokenRepository.deleteById(record.id, trx);
+    return entity.toModel();
   }
 }

--- a/src/api/v1/auth/emails/resetPasswordEmail.ts
+++ b/src/api/v1/auth/emails/resetPasswordEmail.ts
@@ -1,0 +1,8 @@
+export function resetPasswordEmailTemplate(token: string) {
+  const url = `https://example.com/reset-password?token=${token}`;
+  return {
+    subject: "Reset your password",
+    text: `Reset your password by visiting ${url}`,
+    html: `<p>Reset your password by <a href="${url}">clicking here</a>.</p>`,
+  };
+}

--- a/src/api/v1/auth/emails/verificationEmail.ts
+++ b/src/api/v1/auth/emails/verificationEmail.ts
@@ -1,0 +1,8 @@
+export function verificationEmailTemplate(token: string) {
+  const url = `https://example.com/verify?token=${token}`;
+  return {
+    subject: "Verify your email",
+    text: `Please verify your email by visiting ${url}`,
+    html: `<p>Verify your email by <a href="${url}">clicking here</a>.</p>`,
+  };
+}

--- a/src/api/v1/auth/index.ts
+++ b/src/api/v1/auth/index.ts
@@ -2,3 +2,5 @@ export { default as authRoutes } from "./auth.routes";
 export { AuthService } from "./auth.service";
 export { default as AuthRepository } from "./auth.repository";
 export * from "./auth.model";
+export { default as VerificationTokenRepository } from "./verification-token.repository";
+export * from "./verification-token.model";

--- a/src/api/v1/auth/verification-token.model.ts
+++ b/src/api/v1/auth/verification-token.model.ts
@@ -1,0 +1,47 @@
+import { IsDate, IsString, IsUUID } from "class-validator";
+import BaseModel from "@utils/Model";
+
+export enum TokenType {
+  EmailVerification = "email_verification",
+  PasswordReset = "password_reset",
+}
+
+export class VerificationTokenModel extends BaseModel {
+  @IsUUID()
+  userId: string;
+
+  @IsString()
+  token: string;
+
+  @IsString()
+  type: TokenType;
+
+  @IsDate()
+  expiresAt: Date;
+
+  constructor(userId: string, token: string, type: TokenType, expiresAt: Date, id?: string) {
+    super(id);
+    this.userId = userId;
+    this.token = token;
+    this.type = type;
+    this.expiresAt = expiresAt;
+  }
+
+  toRecord(): Record<string, any> {
+    return {
+      id: this.id,
+      user_id: this.userId,
+      token: this.token,
+      type: this.type,
+      expires_at: this.expiresAt,
+      created_at: this.created_at,
+      updated_at: this.updated_at,
+    };
+  }
+
+  static fromRecord(row: any): VerificationTokenModel {
+    return new VerificationTokenModel(row.user_id, row.token, row.type, row.expires_at, row.id);
+  }
+}
+
+export default VerificationTokenModel;

--- a/src/api/v1/auth/verification-token.repository.ts
+++ b/src/api/v1/auth/verification-token.repository.ts
@@ -1,0 +1,44 @@
+import { inject, injectable } from "tsyringe";
+import { Knex } from "knex";
+import DatabaseManager from "@db/db.manager";
+import { KnexRepository } from "@utils/Repository";
+
+import { VerificationTokenModel } from "./verification-token.model";
+
+@injectable()
+export class VerificationTokenRepository extends KnexRepository<VerificationTokenModel> {
+  constructor(@inject(DatabaseManager) protected databaseManager: DatabaseManager) {
+    super(databaseManager);
+  }
+
+  getTableName(): string {
+    return "authentication.verification_tokens";
+  }
+
+  async createToken(
+    userId: string,
+    token: string,
+    type: string,
+    expiresAt: Date,
+    trx?: Knex.Transaction,
+  ): Promise<VerificationTokenModel> {
+    const query = this.getQueryBuilder(trx);
+    const [row] = await query
+      .insert({ user_id: userId, token, type, expires_at: expiresAt })
+      .returning("*");
+    return VerificationTokenModel.fromRecord(row);
+  }
+
+  async findByToken(token: string, trx?: Knex.Transaction): Promise<VerificationTokenModel | null> {
+    const query = this.getQueryBuilder(trx);
+    const row = await query.where({ token }).first();
+    return row ? VerificationTokenModel.fromRecord(row) : null;
+  }
+
+  async deleteById(id: string, trx?: Knex.Transaction): Promise<void> {
+    const query = this.getQueryBuilder(trx);
+    await query.where({ id }).delete();
+  }
+}
+
+export default VerificationTokenRepository;

--- a/src/config/dependencies.ts
+++ b/src/config/dependencies.ts
@@ -6,6 +6,7 @@ import DatabaseFactory from "@db/db.manager";
 import LoggerFactory from "@utils/Logger";
 import DatabaseManager from "@db/db.manager";
 import { AuthRepository, AuthService } from "@api/v1/auth";
+import { VerificationTokenRepository } from "@api/v1/auth";
 import { EventQueue } from "@utils/queue/EventQueue";
 import { DeadLetterQueue } from "@utils/queue/DeadLetterQueue";
 import QueueService from "@api/v1/queue/queue.service";
@@ -65,6 +66,7 @@ export const initializeAppDependencies = (): void => {
       useClass: QueueController,
     });
     container.resolve(DatabaseManager);
+    container.resolve(VerificationTokenRepository);
     container.resolve(AuthRepository);
     container.resolve(AuthService);
     logger.info("Application dependencies initialized successfully.");

--- a/src/migrations/011_create_verification_tokens.ts
+++ b/src/migrations/011_create_verification_tokens.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.withSchema("authentication").createTable("verification_tokens", (table) => {
+    table.uuid("id").primary().defaultTo(knex.raw("uuid_generate_v4()"));
+    table
+      .uuid("user_id")
+      .notNullable()
+      .references("id")
+      .inTable("authentication.users")
+      .onDelete("CASCADE");
+    table.string("token").notNullable().unique();
+    table.string("type").notNullable();
+    table.timestamp("expires_at").notNullable();
+    table.timestamps(true, true);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.withSchema("authentication").dropTableIfExists("verification_tokens");
+}

--- a/src/utils/MailService.ts
+++ b/src/utils/MailService.ts
@@ -1,5 +1,7 @@
 import nodemailer from "nodemailer";
 import { injectable } from "tsyringe";
+import { verificationEmailTemplate } from "@api/v1/auth/emails/verificationEmail";
+import { resetPasswordEmailTemplate } from "@api/v1/auth/emails/resetPasswordEmail";
 
 import LoggerFactory from "./Logger";
 
@@ -29,6 +31,38 @@ export class MailService {
       this.logger.info(`📤 Email sent to ${to}: ${result.messageId}`);
     } catch (err) {
       this.logger.error(`❌ Failed to send email to ${to}:`, err);
+    }
+  }
+
+  async sendVerificationEmail(to: string, token: string) {
+    try {
+      const template = verificationEmailTemplate(token);
+      const result = await this.transporter.sendMail({
+        from: '"Gateway App" <no-reply@gateway.local>',
+        to,
+        subject: template.subject,
+        text: template.text,
+        html: template.html,
+      });
+      this.logger.info(`📤 Verification email sent to ${to}: ${result.messageId}`);
+    } catch (err) {
+      this.logger.error(`❌ Failed to send verification email to ${to}:`, err);
+    }
+  }
+
+  async sendPasswordResetEmail(to: string, token: string) {
+    try {
+      const template = resetPasswordEmailTemplate(token);
+      const result = await this.transporter.sendMail({
+        from: '"Gateway App" <no-reply@gateway.local>',
+        to,
+        subject: template.subject,
+        text: template.text,
+        html: template.html,
+      });
+      this.logger.info(`📤 Password reset email sent to ${to}: ${result.messageId}`);
+    } catch (err) {
+      this.logger.error(`❌ Failed to send password reset email to ${to}:`, err);
     }
   }
 }

--- a/src/utils/queue/EventTypes.ts
+++ b/src/utils/queue/EventTypes.ts
@@ -1,6 +1,8 @@
 export enum EventType {
   UserRegistered = "UserRegistered",
   PermissionUpdated = "PermissionUpdated",
+  EmailVerification = "EmailVerification",
+  PasswordReset = "PasswordReset",
 }
 
 interface JobMetadata {
@@ -26,7 +28,19 @@ export interface PermissionUpdatedPayload extends BasePayload {
   changedBy: string;
 }
 
+export interface EmailVerificationPayload extends BasePayload {
+  email: string;
+  token: string;
+}
+
+export interface PasswordResetPayload extends BasePayload {
+  email: string;
+  token: string;
+}
+
 export type EventPayloadMap = {
   [EventType.UserRegistered]: UserRegisteredPayload;
   [EventType.PermissionUpdated]: PermissionUpdatedPayload;
+  [EventType.EmailVerification]: EmailVerificationPayload;
+  [EventType.PasswordReset]: PasswordResetPayload;
 };

--- a/src/utils/queue/Worker.ts
+++ b/src/utils/queue/Worker.ts
@@ -9,6 +9,8 @@ import {
   EventType,
   PermissionUpdatedPayload,
   UserRegisteredPayload,
+  EmailVerificationPayload,
+  PasswordResetPayload,
 } from "./EventTypes";
 import { DeadLetterQueue } from "./DeadLetterQueue";
 
@@ -28,6 +30,14 @@ const handlers: {
     const { userId, permissionId, changedBy } = job.data;
     // TODO: Implement permission updated email
     // await mailService.sendPermissionUpdatedEmail(userId, permissionId, changedBy);
+  },
+  [EventType.EmailVerification]: async (job: Job<EmailVerificationPayload, any, EventType>) => {
+    const { email, token } = job.data;
+    await mailService.sendVerificationEmail(email, token);
+  },
+  [EventType.PasswordReset]: async (job: Job<PasswordResetPayload, any, EventType>) => {
+    const { email, token } = job.data;
+    await mailService.sendPasswordResetEmail(email, token);
   },
 };
 


### PR DESCRIPTION
## Summary
- support email verification and password reset tokens
- extend mail service with verification and reset templates
- add token repository and migration
- expose `/auth/verify-email` and `/auth/reset-password` routes
- queue workers handle new email events

## Testing
- `npm test` *(fails: Permission and Auth service tests)*

------
https://chatgpt.com/codex/tasks/task_b_6853d06379d8832b8da5a59c015cec79