### PR TITLE
Refactor MailService to use config for SMTP

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,4 +1,4 @@
-const dotenv = require('dotenv');
+const dotenv = require("dotenv");
 // TODO: Use library like config
 dotenv.config();
 
@@ -12,7 +12,7 @@ const config = {
     retryDelay: process.env.DB_RETRY_DELAY ? parseInt(process.env.DB_RETRY_DELAY, 10) : 1000,
   },
   server: {
-    environment: process.env.NODE_ENV || 'development',
+    environment: process.env.NODE_ENV || "development",
     shutdownTimeout: process.env.SERVER_SHUTDOWN_TIMEOUT
       ? parseInt(process.env.SERVER_SHUTDOWN_TIMEOUT, 10)
       : 30000,
@@ -20,23 +20,29 @@ const config = {
   },
   app: {
     session: {
-      secret: process.env.APP_SESSION_SECRET || 'app-session-secret',
+      secret: process.env.APP_SESSION_SECRET || "app-session-secret",
       cookie: {
         maxAge: process.env.APP_SESSION_COOKIE_MAX_AGE
           ? parseInt(process.env.APP_SESSION_COOKIE_MAX_AGE, 10)
           : 300000,
       },
       redis: {
-        host: process.env.REDIS_HOST || 'redis',
+        host: process.env.REDIS_HOST || "redis",
         port: process.env.REDIS_PORT ? parseInt(process.env.REDIS_PORT, 10) : 6379,
-        password: process.env.APP_SESSION_REDIS_PASSWORD || '',
-        prefix: process.env.APP_SESSION_REDIS_PREFIX || 'session:',
+        password: process.env.APP_SESSION_REDIS_PASSWORD || "",
+        prefix: process.env.APP_SESSION_REDIS_PREFIX || "session:",
       },
+    },
+    mail: {
+      host: process.env.SMTP_HOST || "smtp.gmail.com",
+      port: process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT, 10) : 587,
+      user: process.env.SMTP_USER || "",
+      pass: process.env.SMTP_PASS || "",
     },
   },
 };
 
-console.log('Redis Host:', process.env.REDIS_HOST);
-console.log('Redis Port:', process.env.REDIS_PORT);
+console.log("Redis Host:", process.env.REDIS_HOST);
+console.log("Redis Port:", process.env.REDIS_PORT);
 
 export default config;

--- a/src/utils/MailService.ts
+++ b/src/utils/MailService.ts
@@ -1,5 +1,6 @@
 import nodemailer from "nodemailer";
 import { injectable } from "tsyringe";
+import Config from "@config/config";
 
 import LoggerFactory from "./Logger";
 
@@ -10,9 +11,16 @@ export class MailService {
 
   constructor() {
     this.transporter = nodemailer.createTransport({
-      host: "smtp.gmail.com",
-      port: 587,
+      host: Config.app.mail.host,
+      port: Config.app.mail.port,
       secure: false,
+      auth:
+        Config.app.mail.user && Config.app.mail.pass
+          ? {
+              user: Config.app.mail.user,
+              pass: Config.app.mail.pass,
+            }
+          : undefined,
     });
   }
 


### PR DESCRIPTION
## Summary
- load SMTP host/port/credentials via configuration
- update config to expose `app.mail`

## Testing
- `npx jest --runInBand --json --outputFile=/tmp/jest.json`

------
https://chatgpt.com/codex/tasks/task_b_6853d2c73fcc832bafba35dc984ec160