### PR TITLE
Add analytics logging support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,7 @@ A robust, scalable API Gateway built with Express.js and TypeScript implementing
   - Advanced logging with Winston
   - Log rotation and management
   - Error handling and reporting
+  - Optional ELK stack integration for analytics
 
 - **Dependency Injection**:
   - Inversion of Control (IoC) container
@@ -141,6 +142,10 @@ REDIS_PORT=6379
 # Logging
 LOG_LEVEL=info
 LOG_FILE_PATH=logs/app-%DATE%.log
+# Analytics
+ANALYTICS_ENABLED=true
+ANALYTICS_URL=http://analytics:5044
+ANALYTICS_LOG_LEVEL=info
 ```
 
 `REDIS_HOST` and `REDIS_PORT` control the address of the Redis instance used for session storage. If these variables are not set, the gateway defaults to `redis` and `6379`.
@@ -162,6 +167,12 @@ For building the production environment:
 ```bash
 docker-compose -f docker-compose.prod.yml up --build
 ```
+
+### Analytics Dashboard
+
+After the services start, navigate to `http://localhost:5601` to access Kibana
+and explore the collected logs. Ensure `ANALYTICS_ENABLED` is set to `true` so
+logs are forwarded to the analytics container defined in the compose files.
 
 ## API Documentation
 
@@ -192,6 +203,11 @@ The application uses Winston for logging. Logs are stored in daily-rotated files
 
 - Use `LoggerFactory.getLogger()` to get a logger instance.
 - Log levels: error, warn, info, debug
+
+If `ANALYTICS_ENABLED` is set to `true`, logs are also forwarded to the
+analytics stack via the URL configured in `ANALYTICS_URL`. When running the
+provided Docker compose files, Kibana is available at `http://localhost:5601`
+for exploring collected logs.
 
 ### Error Handling
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -58,6 +58,15 @@ services:
       - .env
     networks:
       - express-gateway-network
+  analytics:
+    container_name: analytics
+    image: sebp/elk
+    ports:
+      - "5601:5601" # Kibana
+      - "9200:9200" # Elasticsearch
+      - "5044:5044" # Logstash
+    networks:
+      - express-gateway-network
 networks:
   express-gateway-network:
     driver: bridge

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,4 +23,10 @@ services:
     depends_on:
       - db
       - redis
+  analytics:
+    image: sebp/elk
+    ports:
+      - "5601:5601"
+      - "9200:9200"
+      - "5044:5044"
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -40,6 +40,11 @@ const config = {
       pass: process.env.SMTP_PASS || "",
     },
   },
+  analytics: {
+    enabled: process.env.ANALYTICS_ENABLED === "true",
+    url: process.env.ANALYTICS_URL || "",
+    logLevel: process.env.ANALYTICS_LOG_LEVEL || "info",
+  },
 };
 
 export default config;

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -15,22 +15,34 @@ class LoggerFactory {
    * @private
    * */
   private static createAsyncLogger(): Logger {
+    const transportList = [
+      new transports.Console({
+        handleExceptions: true,
+      }),
+      new transports.DailyRotateFile({
+        filename: process.env.LOG_FILE_PATH || "app-%DATE%.log",
+        datePattern: "YYYY-MM-DD",
+        zippedArchive: true,
+        maxSize: "20m",
+        maxFiles: "14d",
+        handleExceptions: true,
+      }),
+    ];
+
+    if (process.env.ANALYTICS_ENABLED === "true" && process.env.ANALYTICS_URL) {
+      transportList.push(
+        new transports.Http({
+          level: process.env.ANALYTICS_LOG_LEVEL || "info",
+          url: process.env.ANALYTICS_URL,
+          handleExceptions: true,
+        }),
+      );
+    }
+
     return createLogger({
       level: process.env.LOG_LEVEL || "info",
       format: format.combine(format.timestamp(), format.json()),
-      transports: [
-        new transports.Console({
-          handleExceptions: true,
-        }),
-        new transports.DailyRotateFile({
-          filename: process.env.LOG_FILE_PATH || "app-%DATE%.log",
-          datePattern: "YYYY-MM-DD",
-          zippedArchive: true,
-          maxSize: "20m",
-          maxFiles: "14d",
-          handleExceptions: true,
-        }),
-      ],
+      transports: transportList,
     });
   }
 


### PR DESCRIPTION
## Summary
- integrate optional ELK analytics service in dev/prod compose files
- allow Logger to send logs to analytics service
- expose analytics settings in config
- document analytics usage and dashboard in Readme

## Testing
- `npm test` *(fails: Cannot find module '@middlewares' in several tests)*

------
https://chatgpt.com/codex/tasks/task_b_6853dbd090f0832b98e6087bfc572a29