### PR TITLE
Fix ts-node path resolution for worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "scripts": {
     "start": "node dist/index.js",
-    "start:worker": "ts-node src/utils/queue/Worker.ts",
+    "start:worker": "ts-node -r tsconfig-paths/register src/utils/queue/Worker.ts",
     "build": "tsc",
     "dev": "tsx watch --inspect=0.0.0.0:9229 src/index.ts",
     "test": "jest",


### PR DESCRIPTION
## Summary
- use tsconfig-paths register when running worker so ts-node resolves aliases

## Testing
- `npm test` *(fails: Cannot find module '@middlewares' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6853f6950c7c832ba80721c6bac72ec1