### PR TITLE
Fix env var quoting and jest path for middlewares

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -67,7 +67,7 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
       - http.cors.enabled=true
-      - http.cors.allow-origin=* # adjust this for prod
+      - "http.cors.allow-origin=*" # adjust this for prod
     ulimits:
       memlock:
         soft: -1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
       - http.cors.enabled=true
-      - http.cors.allow-origin=* # adjust this for prod
+      - "http.cors.allow-origin=*" # adjust this for prod
     ulimits:
       memlock:
         soft: -1

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,7 @@ module.exports = {
     "^@config/(.*)$": "<rootDir>/src/config/$1",
     "^@db/(.*)$": "<rootDir>/src/db/$1",
     "^@middlewares/(.*)$": "<rootDir>/src/middlewares/$1",
+    "^@middlewares$": "<rootDir>/src/middlewares",
   },
   globals: {
     "ts-jest": {


### PR DESCRIPTION
## Summary
- quote Elasticsearch CORS setting in docker-compose files
- handle `@middlewares` path alias in Jest config

## Testing
- `npx jest --runInBand --bail` *(fails: Cannot find module '@middlewares' and some permission service tests)*

------
https://chatgpt.com/codex/tasks/task_b_68542c02a830832b85e00d512a52a392