### PR TITLE
Add health endpoints and container healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ FROM build AS development
 RUN npm install -g tsx knex @types/node
 ENV NODE_ENV=development
 EXPOSE 8000 9229
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD curl -f http://localhost:${PORT:-8000}/health/ready || exit 1
 CMD ["./scripts/wait-for-it.sh", "postgres:5432", "--", "sh", "-c", "./scripts/docker/prepare.sh ./scripts/docker/start-app.sh"]
 
 # Production Stage
@@ -22,5 +24,7 @@ RUN npm ci --omit=dev
 COPY --from=build /usr/src/app/dist ./dist
 COPY scripts/wait-for-it.sh ./scripts/wait-for-it.sh
 EXPOSE 8000
-CMD ["./scripts/wait-for-it.sh", "postgres:5432", "--", "node", "dist/index.js"]
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD curl -f http://localhost:${PORT:-8000}/health/ready || exit 1
+CMD ["./scripts/wait-for-it.sh", "postgres:5432", "--", "sh", "-c", "./scripts/docker/start-app.sh"]
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -18,6 +18,13 @@ services:
     env_file:
       - .env
     entrypoint: ./scripts/docker/start-app.sh
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${DEV_PORT:-8000}/health/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: on-failure
     depends_on:
       - db
       - redis
@@ -39,6 +46,13 @@ services:
     env_file:
       - .env
     entrypoint: /start-worker.sh
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://express:${DEV_PORT:-8000}/health/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: on-failure
     depends_on:
       - express
       - db
@@ -53,6 +67,11 @@ services:
       - "5432:5432"
     env_file:
       - .env
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 30s
+      retries: 5
+    restart: on-failure
     networks:
       - express-gateway-network
 
@@ -63,6 +82,12 @@ services:
       - "${REDIS_PORT:-6379}:${REDIS_PORT:-6379}"
     env_file:
       - .env
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -h localhost ping | grep -q PONG"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: on-failure
     networks:
       - express-gateway-network
 
@@ -97,6 +122,13 @@ services:
       - ./scripts/wait-for-it.sh:/wait-for-it.sh
       - ./scripts/docker/start-kibana.sh:/start-kibana.sh
     entrypoint: /start-kibana.sh
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5601/api/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    restart: on-failure
     depends_on:
       - elasticsearch
     networks:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,13 @@ services:
       - "${PORT:-80}:${PORT:-80}"
     env_file:
       - .env.prod
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${PORT:-80}/health/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: on-failure
 
   worker:
     build:
@@ -20,6 +27,13 @@ services:
     command: npm run start:worker
     env_file:
       - .env.prod
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://express:${PORT:-80}/health/ready || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: on-failure
     depends_on:
       - db
       - redis
@@ -41,6 +55,12 @@ services:
       - esdata:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: on-failure
 
   kibana:
     image: docker.elastic.co/kibana/kibana:8.17.6
@@ -49,6 +69,13 @@ services:
       - "5601:5601"
     environment:
       - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5601/api/status || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    restart: on-failure
     depends_on:
       - elasticsearch
 volumes:

--- a/scripts/docker/start-app.sh
+++ b/scripts/docker/start-app.sh
@@ -1,3 +1,25 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
-exec tsx -r tsconfig-paths/register --watch --inspect=0.0.0.0:9229 src/index.ts
+
+# Wait for dependencies
+./scripts/wait-for-it.sh postgres:5432 -- echo "Postgres is up"
+./scripts/wait-for-it.sh redis:6379 -- echo "Redis is up"
+
+if [ "$NODE_ENV" = "production" ]; then
+  node dist/index.js &
+else
+  tsx -r tsconfig-paths/register --watch --inspect=0.0.0.0:9229 src/index.ts &
+fi
+APP_PID=$!
+
+cleanup() {
+  echo "⏳ Signal received — shutting down app (pid $APP_PID)…"
+  kill -TERM "$APP_PID" 2>/dev/null
+  wait "$APP_PID"
+  echo "✔️ App exited cleanly"
+  exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+wait "$APP_PID"

--- a/scripts/docker/start-kibana.sh
+++ b/scripts/docker/start-kibana.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 chmod +x /wait-for-it.sh
@@ -6,5 +6,17 @@ chmod +x /wait-for-it.sh
 echo "Waiting for Elasticsearch..."
 /wait-for-it.sh elasticsearch:9200 --timeout=600 --strict
 
-echo "Starting Kibana..."
-exec /bin/tini -- /usr/share/kibana/bin/kibana
+/bin/tini -- /usr/share/kibana/bin/kibana &
+APP_PID=$!
+
+cleanup() {
+  echo "⏳ Signal received — shutting down Kibana (pid $APP_PID)…"
+  kill -TERM "$APP_PID" 2>/dev/null
+  wait "$APP_PID"
+  echo "✔️ Kibana exited cleanly"
+  exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+wait "$APP_PID"

--- a/scripts/docker/start-worker.sh
+++ b/scripts/docker/start-worker.sh
@@ -1,9 +1,26 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 chmod +x /wait-for-it.sh
 
+# Wait for dependencies
 /wait-for-it.sh express:8000 --timeout=120 --strict
+echo "Waiting for Postgres..."
+/wait-for-it.sh postgres:5432 --timeout=120 --strict
+echo "Waiting for Redis..."
+/wait-for-it.sh redis:6379 --timeout=120 --strict
 
-echo "Starting worker..."
-exec npm run start:worker
+npm run start:worker &
+APP_PID=$!
+
+cleanup() {
+  echo "⏳ Signal received — shutting down worker (pid $APP_PID)…"
+  kill -TERM "$APP_PID" 2>/dev/null
+  wait "$APP_PID"
+  echo "✔️ Worker exited cleanly"
+  exit 0
+}
+
+trap cleanup SIGTERM SIGINT
+
+wait "$APP_PID"

--- a/src/app.ts
+++ b/src/app.ts
@@ -6,12 +6,16 @@ import LoggerFactory from "@utils/Logger";
 
 import * as middlewares from "./middlewares";
 import { api_v1 } from "./api/v1/";
+import { healthRouter } from "./health";
 
 const app = express();
 const logger = LoggerFactory.getLogger();
 
 app.use(express.json());
 app.use(middlewares.logger);
+
+// Mount health routes before other middleware
+app.use(healthRouter);
 
 app.use(getSessionMiddleware());
 setupSwagger(app);

--- a/src/health.ts
+++ b/src/health.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { container } from "tsyringe";
+import DatabaseManager from "@db/db.manager";
+import { RedisManager } from "@utils/RedisManager";
+
+export const healthRouter = Router();
+
+healthRouter.get("/health/live", (_req, res) => {
+  res.sendStatus(200);
+});
+
+healthRouter.get("/health/ready", async (_req, res) => {
+  try {
+    const dbManager = container.resolve(DatabaseManager);
+    const redisManager = container.resolve(RedisManager);
+    await dbManager.getDatabase().query("SELECT 1");
+    await redisManager.getRedisClient().ping();
+    res.status(200).json({ db: "ok", redis: "ok" });
+  } catch (err: any) {
+    console.error("Readiness check failed:", err);
+    res.status(503).json({ status: "fail", details: err?.message || String(err) });
+  }
+});


### PR DESCRIPTION
## Summary
- implement `/health/live` and `/health/ready` endpoints
- wire the health router early in `app.ts`
- add healthcheck instructions in Dockerfile
- configure compose files with healthchecks and restarts
- improve container entrypoint scripts for graceful shutdown

## Testing
- `npx jest --runInBand --silent --json --outputFile=/tmp/test.json`


------
https://chatgpt.com/codex/tasks/task_b_6856f89d7bf8832b80c0f9a8fc598850