### PR TITLE
Slimmer Docker image with non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,23 @@ EXPOSE 8000 9229
 CMD ["./scripts/wait-for-it.sh", "postgres:5432", "--", "sh", "-c", "./scripts/docker/prepare.sh ./scripts/docker/start-app.sh"]
 
 # Production Stage
-FROM node:18-slim AS production
+# Use the Alpine variant for a smaller final image
+FROM node:18-alpine AS production
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
-COPY package*.json ./
+
+# Copy only lock files for reliable, cached installs
+COPY --chown=node:node package*.json ./
 RUN npm ci --omit=dev
-COPY --from=build /usr/src/app/dist ./dist
-COPY scripts/wait-for-it.sh ./scripts/wait-for-it.sh
+
+# Copy the compiled output only
+COPY --from=build --chown=node:node /usr/src/app/dist ./dist
+COPY --chown=node:node scripts/wait-for-it.sh ./scripts/wait-for-it.sh
+
 EXPOSE 8000
+
+# Drop root privileges for security
+USER node
+
 CMD ["./scripts/wait-for-it.sh", "postgres:5432", "--", "node", "dist/index.js"]
 


### PR DESCRIPTION
## Summary
- optimize Dockerfile's production stage
- use `node:18-alpine` for smaller runtime
- install production deps only and copy only compiled files
- drop root privileges with the `node` user

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6856fa00cf40832b822f9a4b4e592585