### PR TITLE
Add SSR admin dashboard

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,135 +1,40 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { AuthProvider, useAuth } from "./components/AuthContext";
 import Login from "./components/Login";
-import Health from "./components/Health";
+import AdminDashboard from "./components/AdminDashboard";
 
-interface QueueItem {
-  id: string;
-  data: any;
-  status: string;
-}
-
-interface QueueDashboardProps {
-  isAdmin: boolean;
-}
-
-const QueueDashboard = ({ isAdmin }: QueueDashboardProps) => {
-  // State for a message shown in the UI and for the queue items.
-  const [msg, setMsg] = useState("Waiting for WebSocket...");
-  const [queueItems, setQueueItems] = useState<QueueItem[]>([]);
-  const { logout } = useAuth();
-
-  // Function to fetch active queue items from /api/v1/queue/items
-  const fetchQueueItems = async () => {
-    console.log("Fetching queue items...");
-    try {
-      // Include credentials if necessary:
-      const response = await fetch("/api/v1/queue/items", { credentials: "include" });
-      if (!response.ok) {
-        console.error("Failed to fetch items, status:", response.status);
-        setQueueItems([]);
-        return;
-      }
-      const data = await response.json();
-      if (!Array.isArray(data)) {
-        console.error("Error: Fetched data is not an array", data);
-        setQueueItems([]);
-        return;
-      }
-      setQueueItems(data);
-    } catch (err) {
-      console.error("Error fetching queue items:", err);
-      setQueueItems([]);
-    }
-  };
-
-  useEffect(() => {
-    console.log("📡 Connecting to WebSocket...");
-    const ws = new WebSocket(`ws://${window.location.host}`);
-
-    ws.onopen = () => {
-      console.log("✅ WebSocket connected");
-    };
-
-    ws.onerror = (error) => {
-      console.error("❌ WebSocket error", error);
-    };
-
-    ws.onclose = () => {
-      console.warn("🔌 WebSocket connection closed");
-    };
-
-    ws.onmessage = async (event) => {
-      console.log("📨 Received message:", event.data);
-      try {
-        const data = JSON.parse(event.data);
-        if (data && data.type === "refresh") {
-          console.log("Triggering fetch due to refresh message...");
-          await fetchQueueItems();
-          setMsg("Fetching active jobs...");
-        } else if (data && data.message) {
-          setMsg(data.message);
-        }
-      } catch (err) {
-        console.error("Error parsing WS message:", err);
-      }
-    };
-
-    // Optionally, trigger an initial fetch
-    fetchQueueItems();
-
-    return () => {
-      ws.close();
-    };
-  }, []);
-
-  return (
-    <div className="app">
-      <div className="container">
-        <div className="header">
-          <div className="header-left">
-            <h1>Queue Dashboard</h1>
-            <p>{msg}</p>
-          </div>
-          <div className="header-right">
-            <button className="primary" onClick={() => fetchQueueItems()}>
-              Refetch Jobs
-            </button>
-            <button className="secondary" onClick={logout}>
-              Logout
-            </button>
-          </div>
-        </div>
-        <div className="content">
-          <h2>Active Queue Items</h2>
-          <ul>
-            {Array.isArray(queueItems) && queueItems.length > 0 ? (
-              queueItems.map((item) => (
-                <li key={item.id}>
-                  <div>ID: {item.id}</div>
-                  <div>Status: {item.status}</div>
-                  <div>Data: {JSON.stringify(item.data)}</div>
-                </li>
-              ))
-            ) : (
-              <li>No jobs found.</li>
-            )}
-          </ul>
-          {isAdmin && <Health />}
-        </div>
-      </div>
-    </div>
-  );
+const Redirect = ({ to }: { to: string }) => {
+  if (typeof window !== "undefined") {
+    window.location.href = to;
+  }
+  return null;
 };
 
-const AppContent = () => {
+interface AppProps {
+  initialData?: any;
+  path?: string;
+}
+
+const AppContent = ({ initialData, path }: AppProps) => {
   const { isAuthenticated, isAdmin } = useAuth();
-  return isAuthenticated ? <QueueDashboard isAdmin={isAdmin} /> : <Login />;
+  const currentPath =
+    typeof window !== "undefined" ? window.location.pathname : path || "";
+
+  if (!isAuthenticated) {
+    return currentPath === "/login" ? <Login /> : <Redirect to="/login" />;
+  }
+  if (!isAdmin) {
+    return <Redirect to="/login" />;
+  }
+  if (currentPath.startsWith("/admin")) {
+    return <AdminDashboard {...initialData} />;
+  }
+  return <Redirect to="/admin/dashboard" />;
 };
 
-const App = () => (
+const App = (props: AppProps) => (
   <AuthProvider>
-    <AppContent />
+    <AppContent {...props} />
   </AuthProvider>
 );
 

--- a/src/ui/components/AdminDashboard.tsx
+++ b/src/ui/components/AdminDashboard.tsx
@@ -1,0 +1,260 @@
+import React, { useEffect, useState } from "react";
+import Navbar from "./Navbar";
+import Health from "./Health";
+
+interface QueueItem {
+  id: string;
+  status: string;
+  data: any;
+}
+interface User {
+  id: string;
+  email?: string;
+  [key: string]: any;
+}
+interface Role {
+  id: string;
+  name: string;
+  permissions?: Permission[];
+}
+interface Permission {
+  id: string;
+  name: string;
+}
+
+interface AdminDashboardProps {
+  queueItems?: QueueItem[];
+  users?: User[];
+  roles?: Role[];
+  permissions?: Permission[];
+}
+
+const AdminDashboard = (props: AdminDashboardProps) => {
+  const initial =
+    typeof window !== "undefined" ? (window as any).__INITIAL_DATA__ || {} : {};
+
+  const [queueItems, setQueueItems] = useState<QueueItem[]>(
+    props.queueItems || initial.queueItems || [],
+  );
+  const [users, setUsers] = useState<User[]>(props.users || initial.users || []);
+  const [roles, setRoles] = useState<Role[]>(props.roles || initial.roles || []);
+  const [permissions, setPermissions] = useState<Permission[]>(
+    props.permissions || initial.permissions || [],
+  );
+
+  const [newRole, setNewRole] = useState("");
+  const [selectedPerms, setSelectedPerms] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const ws = new WebSocket(`ws://${window.location.host}/admin`);
+    ws.onmessage = (evt) => {
+      try {
+        const data = JSON.parse(evt.data);
+        if (data.type === "queue_update" && data.items) {
+          setQueueItems(data.items);
+        }
+      } catch (err) {
+        console.error("ws message error", err);
+      }
+    };
+    return () => ws.close();
+  }, []);
+
+  const path =
+    typeof window !== "undefined" ? window.location.pathname : "/admin/dashboard";
+
+  const refetchQueue = async () => {
+    try {
+      const res = await fetch(`/api/v1/queue/items`, {
+        credentials: "include",
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setQueueItems(data);
+      } else {
+        alert("Failed to fetch queue items");
+      }
+    } catch (err) {
+      alert("Failed to fetch queue items");
+    }
+  };
+
+  const deleteUser = async (id: string) => {
+    try {
+      const res = await fetch(`/api/v1/admin/users/${id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (res.ok) {
+        setUsers(users.filter((u) => u.id !== id));
+      } else {
+        alert("Failed to delete user");
+      }
+    } catch (err) {
+      alert("Failed to delete user");
+    }
+  };
+
+  const createRole = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const res = await fetch(`/api/v1/admin/roles`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newRole, permissionIds: selectedPerms }),
+      });
+      if (res.ok) {
+        const role = await res.json();
+        setRoles([...roles, role]);
+        setNewRole("");
+        setSelectedPerms([]);
+      } else {
+        alert("Failed to create role");
+      }
+    } catch (err) {
+      alert("Failed to create role");
+    }
+  };
+
+  const deleteRole = async (id: string) => {
+    try {
+      const res = await fetch(`/api/v1/admin/roles/${id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (res.ok) {
+        setRoles(roles.filter((r) => r.id !== id));
+      } else {
+        alert("Failed to delete role");
+      }
+    } catch (err) {
+      alert("Failed to delete role");
+    }
+  };
+
+  const renderDashboard = () => (
+    <div className="content">
+      <h2>Overview</h2>
+      <ul>
+        <li>Queue Items: {queueItems.length}</li>
+        <li>Users: {users.length}</li>
+        <li>Roles: {roles.length}</li>
+        <li>Permissions: {permissions.length}</li>
+      </ul>
+    </div>
+  );
+
+  const renderQueues = () => (
+    <div className="content">
+      <h2>Queues</h2>
+      <button className="primary" onClick={refetchQueue}>
+        Refetch
+      </button>
+      <ul>
+        {queueItems.map((q) => (
+          <li key={q.id}>
+            <div>ID: {q.id}</div>
+            <div>Status: {q.status}</div>
+            <div>Data: {JSON.stringify(q.data)}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  const renderUsers = () => (
+    <div className="content">
+      <h2>Users</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Email</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((u) => (
+            <tr key={u.id}>
+              <td>{u.id}</td>
+              <td>{u.email}</td>
+              <td>
+                <button className="secondary" onClick={() => deleteUser(u.id)}>
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  const renderRoles = () => (
+    <div className="content">
+      <h2>Roles</h2>
+      <ul>
+        {roles.map((r) => (
+          <li key={r.id}>
+            {r.name}
+            <button className="secondary" onClick={() => deleteRole(r.id)}>
+              Delete
+            </button>
+            <ul>
+              {r.permissions?.map((p) => (
+                <li key={p.id}>{p.name}</li>
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={createRole}>
+        <input
+          type="text"
+          value={newRole}
+          onChange={(e) => setNewRole(e.target.value)}
+          placeholder="Role name"
+          required
+        />
+        <select
+          multiple
+          value={selectedPerms}
+          onChange={(e) =>
+            setSelectedPerms(
+              Array.from(e.target.selectedOptions).map((o) => o.value),
+            )
+          }
+        >
+          {permissions.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <button className="primary" type="submit">
+          Create Role
+        </button>
+      </form>
+    </div>
+  );
+
+  let content: React.ReactNode = null;
+  if (path.startsWith("/admin/queues")) content = renderQueues();
+  else if (path.startsWith("/admin/health")) content = <Health />;
+  else if (path.startsWith("/admin/users")) content = renderUsers();
+  else if (path.startsWith("/admin/roles")) content = renderRoles();
+  else content = renderDashboard();
+
+  return (
+    <div className="app">
+      <div className="container">
+        <Navbar />
+        {content}
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboard;

--- a/src/ui/components/Navbar.tsx
+++ b/src/ui/components/Navbar.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const Navbar = () => {
+  return (
+    <div className="header">
+      <div className="header-left">
+        <h1>Admin Dashboard</h1>
+      </div>
+      <div className="header-right">
+        <a href="/admin/dashboard">
+          <button className="primary">Dashboard</button>
+        </a>
+        <a href="/admin/queues">
+          <button className="primary">Queues</button>
+        </a>
+        <a href="/admin/health">
+          <button className="primary">Health</button>
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default Navbar;

--- a/src/ui/entry-client.tsx
+++ b/src/ui/entry-client.tsx
@@ -2,4 +2,6 @@ console.log("hello world");
 import React from "react";
 import { hydrateRoot } from "react-dom/client";
 import App from "./App";
-hydrateRoot(document.getElementById("root")!, <App />);
+
+const data = (window as any).__INITIAL_DATA__ || {};
+hydrateRoot(document.getElementById("root")!, <App initialData={data} />);

--- a/src/ui/entry-server.tsx
+++ b/src/ui/entry-server.tsx
@@ -2,6 +2,32 @@ import React from "react";
 import { renderToString } from "react-dom/server";
 import App from "./App";
 
-export function render() {
-  return renderToString(<App />);
+export async function render(url: string) {
+  let initialData: any = {};
+  if (url.startsWith("/admin")) {
+    try {
+      const base = `http://localhost:${process.env.PORT || 8000}`;
+      const [q, u, r, p] = await Promise.all([
+        fetch(`${base}/api/v1/queue/items`, { credentials: "include" }),
+        fetch(`${base}/api/v1/admin/users`, { credentials: "include" }),
+        fetch(`${base}/api/v1/admin/roles`, { credentials: "include" }),
+        fetch(`${base}/api/v1/admin/permissions`, { credentials: "include" }),
+      ]);
+      const [queueItems, users, roles, permissions] = await Promise.all([
+        q.json(),
+        u.json(),
+        r.json(),
+        p.json(),
+      ]);
+      initialData = { queueItems, users, roles, permissions };
+    } catch (err) {
+      console.error("failed to fetch initial data", err);
+    }
+  }
+
+  const html = renderToString(
+    <App initialData={initialData} path={url} />,
+  );
+  const script = `<script>window.__INITIAL_DATA__ = ${JSON.stringify(initialData)}</script>`;
+  return url.startsWith("/admin") ? `${html}${script}` : html;
 }


### PR DESCRIPTION
## Summary
- create `Navbar` with links to dashboard sections
- build `AdminDashboard` component for admin views and WebSocket updates
- update routing logic in `App.tsx`
- fetch admin data on server side in `entry-server.tsx`
- hydrate with initial data in `entry-client.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68572a8ebb64832b85331c2befa97d42